### PR TITLE
MainViewController에서 child를 붙였다 뗐다할 수 있도록 변경

### DIFF
--- a/Nanagong/Nanagong.xcodeproj/project.pbxproj
+++ b/Nanagong/Nanagong.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		EDC4C3F52736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3F42736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift */; };
 		EDC4C3F72736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3F62736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift */; };
 		EDC4C3F92736DEA000B4E162 /* RegisterLessonGoalViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3F82736DEA000B4E162 /* RegisterLessonGoalViewFactory.swift */; };
+		EDC4C4002738020100B4E162 /* UIViewController+Child.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */; };
 		EDCFB887272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB886272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift */; };
 		EDCFB889272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB888272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift */; };
 		EDCFB88B272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB88A272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift */; };
@@ -122,6 +123,7 @@
 		EDC4C3F42736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlothSelectDateInputFormViewModel.swift; sourceTree = "<group>"; };
 		EDC4C3F62736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonGoalInputFormViewFactory.swift; sourceTree = "<group>"; };
 		EDC4C3F82736DEA000B4E162 /* RegisterLessonGoalViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonGoalViewFactory.swift; sourceTree = "<group>"; };
+		EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Child.swift"; sourceTree = "<group>"; };
 		EDCFB886272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonInformationInputFormViewFactory.swift; sourceTree = "<group>"; };
 		EDCFB888272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonInformationViewPickerFactory.swift; sourceTree = "<group>"; };
 		EDCFB88A272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonViewCoordiantor.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				ED9403612719CDF0006D32A6 /* Model */,
 				ED47DD4F272718AD002AC5FB /* View */,
 				ED47DD4E2727189B002AC5FB /* ViewModel */,
+				EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -563,6 +566,7 @@
 				ED94035527191E1B006D32A6 /* EndPoint.swift in Sources */,
 				EDE5E08C272CC90D00B2AFAF /* LessonInformation.swift in Sources */,
 				ED94035327191536006D32A6 /* SignInRepository.swift in Sources */,
+				EDC4C4002738020100B4E162 /* UIViewController+Child.swift in Sources */,
 				EDC4C3F32736C2D200B4E162 /* SlothSelectDateInputFormView.swift in Sources */,
 				AB538AE3272C490D007776E2 /* KeyChainManager.swift in Sources */,
 				ED4976FF2732FAC900EBF879 /* SignInViewCoordinator.swift in Sources */,

--- a/Nanagong/Nanagong.xcodeproj/project.pbxproj
+++ b/Nanagong/Nanagong.xcodeproj/project.pbxproj
@@ -57,7 +57,10 @@
 		EDC4C3F52736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3F42736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift */; };
 		EDC4C3F72736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3F62736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift */; };
 		EDC4C3F92736DEA000B4E162 /* RegisterLessonGoalViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3F82736DEA000B4E162 /* RegisterLessonGoalViewFactory.swift */; };
+		EDC4C3FE2737F7C200B4E162 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3FD2737F7C200B4E162 /* MainViewController.swift */; };
 		EDC4C4002738020100B4E162 /* UIViewController+Child.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */; };
+		EDC4C402273802CC00B4E162 /* MainViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C401273802CC00B4E162 /* MainViewControllerFactory.swift */; };
+		EDC4C404273802DC00B4E162 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C403273802DC00B4E162 /* MainViewModel.swift */; };
 		EDCFB887272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB886272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift */; };
 		EDCFB889272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB888272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift */; };
 		EDCFB88B272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB88A272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift */; };
@@ -123,7 +126,10 @@
 		EDC4C3F42736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlothSelectDateInputFormViewModel.swift; sourceTree = "<group>"; };
 		EDC4C3F62736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonGoalInputFormViewFactory.swift; sourceTree = "<group>"; };
 		EDC4C3F82736DEA000B4E162 /* RegisterLessonGoalViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonGoalViewFactory.swift; sourceTree = "<group>"; };
+		EDC4C3FD2737F7C200B4E162 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Child.swift"; sourceTree = "<group>"; };
+		EDC4C401273802CC00B4E162 /* MainViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewControllerFactory.swift; sourceTree = "<group>"; };
+		EDC4C403273802DC00B4E162 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		EDCFB886272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonInformationInputFormViewFactory.swift; sourceTree = "<group>"; };
 		EDCFB888272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonInformationViewPickerFactory.swift; sourceTree = "<group>"; };
 		EDCFB88A272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonViewCoordiantor.swift; sourceTree = "<group>"; };
@@ -276,6 +282,8 @@
 				ED47DD4F272718AD002AC5FB /* View */,
 				ED47DD4E2727189B002AC5FB /* ViewModel */,
 				EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */,
+				EDC4C401273802CC00B4E162 /* MainViewControllerFactory.swift */,
+				EDC4C403273802DC00B4E162 /* MainViewModel.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -351,6 +359,14 @@
 			path = SlothPickerViewController;
 			sourceTree = "<group>";
 		};
+		EDC4C3FC2737F7B500B4E162 /* MainViewController */ = {
+			isa = PBXGroup;
+			children = (
+				EDC4C3FD2737F7C200B4E162 /* MainViewController.swift */,
+			);
+			path = MainViewController;
+			sourceTree = "<group>";
+		};
 		EDCFB88C272EFDC500DB7DFE /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -405,6 +421,7 @@
 		EDDC4C76270B050C00AD707F /* Nanagong */ = {
 			isa = PBXGroup;
 			children = (
+				EDC4C3FC2737F7B500B4E162 /* MainViewController */,
 				ED2DC9012720413B003426D6 /* RegisterLessonView */,
 				ED9403602719CDD0006D32A6 /* Common */,
 				ED94035F2719CDC4006D32A6 /* Resources */,
@@ -572,11 +589,13 @@
 				ED4976FF2732FAC900EBF879 /* SignInViewCoordinator.swift in Sources */,
 				AB538AD4272A8E6F007776E2 /* OnBoardingViewController.swift in Sources */,
 				EDC4C3ED2736AFD500B4E162 /* SlothDatePickerViewController.swift in Sources */,
+				EDC4C404273802DC00B4E162 /* MainViewModel.swift in Sources */,
 				AB538AE7272C5849007776E2 /* PrivacyPolicyViewController.swift in Sources */,
 				EDC4C3F72736DE5C00B4E162 /* RegisterLessonGoalInputFormViewFactory.swift in Sources */,
 				AB538AE5272C4E6B007776E2 /* OnBoardingViewModel.swift in Sources */,
 				ED4976FD2732FAA900EBF879 /* SignInViewControllerFactory.swift in Sources */,
 				ABC2FC3B27147F16009B5829 /* GoogleSessionManager.swift in Sources */,
+				EDC4C3FE2737F7C200B4E162 /* MainViewController.swift in Sources */,
 				AB538ADE272C3CF9007776E2 /* KeyChaingWrapper+Extension.swift in Sources */,
 				EDE5E097272CD16900B2AFAF /* RegisterLessonInputForm.swift in Sources */,
 				ED4977022732FD5500EBF879 /* PrivacyPolicyViewCoordinator.swift in Sources */,
@@ -596,6 +615,7 @@
 				ED6BE982272467C40011693B /* SlothTextFieldInputFormViewModel.swift in Sources */,
 				EDC4C3F52736C57200B4E162 /* SlothSelectDateInputFormViewModel.swift in Sources */,
 				EDCFB88B272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift in Sources */,
+				EDC4C402273802CC00B4E162 /* MainViewControllerFactory.swift in Sources */,
 				EDADE818272B107700E96099 /* SlothPickerViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Nanagong/Nanagong.xcodeproj/project.pbxproj
+++ b/Nanagong/Nanagong.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		EDC4C4002738020100B4E162 /* UIViewController+Child.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */; };
 		EDC4C402273802CC00B4E162 /* MainViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C401273802CC00B4E162 /* MainViewControllerFactory.swift */; };
 		EDC4C404273802DC00B4E162 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C403273802DC00B4E162 /* MainViewModel.swift */; };
+		EDC4C407273806B500B4E162 /* SignedInTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C406273806B500B4E162 /* SignedInTabBarController.swift */; };
+		EDC4C4092738083A00B4E162 /* SignedInTabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC4C4082738083A00B4E162 /* SignedInTabBarCoordinator.swift */; };
 		EDCFB887272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB886272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift */; };
 		EDCFB889272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB888272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift */; };
 		EDCFB88B272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDCFB88A272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift */; };
@@ -130,6 +132,8 @@
 		EDC4C3FF2738020100B4E162 /* UIViewController+Child.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Child.swift"; sourceTree = "<group>"; };
 		EDC4C401273802CC00B4E162 /* MainViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewControllerFactory.swift; sourceTree = "<group>"; };
 		EDC4C403273802DC00B4E162 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		EDC4C406273806B500B4E162 /* SignedInTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedInTabBarController.swift; sourceTree = "<group>"; };
+		EDC4C4082738083A00B4E162 /* SignedInTabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedInTabBarCoordinator.swift; sourceTree = "<group>"; };
 		EDCFB886272EF8F800DB7DFE /* RegisterLessonInformationInputFormViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonInformationInputFormViewFactory.swift; sourceTree = "<group>"; };
 		EDCFB888272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonInformationViewPickerFactory.swift; sourceTree = "<group>"; };
 		EDCFB88A272EFB3B00DB7DFE /* RegisterLessonViewCoordiantor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLessonViewCoordiantor.swift; sourceTree = "<group>"; };
@@ -367,6 +371,15 @@
 			path = MainViewController;
 			sourceTree = "<group>";
 		};
+		EDC4C405273806A500B4E162 /* SignedInView */ = {
+			isa = PBXGroup;
+			children = (
+				EDC4C406273806B500B4E162 /* SignedInTabBarController.swift */,
+				EDC4C4082738083A00B4E162 /* SignedInTabBarCoordinator.swift */,
+			);
+			path = SignedInView;
+			sourceTree = "<group>";
+		};
 		EDCFB88C272EFDC500DB7DFE /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -421,6 +434,7 @@
 		EDDC4C76270B050C00AD707F /* Nanagong */ = {
 			isa = PBXGroup;
 			children = (
+				EDC4C405273806A500B4E162 /* SignedInView */,
 				EDC4C3FC2737F7B500B4E162 /* MainViewController */,
 				ED2DC9012720413B003426D6 /* RegisterLessonView */,
 				ED9403602719CDD0006D32A6 /* Common */,
@@ -580,6 +594,7 @@
 				EDFF069F271481BE009A0B32 /* AppleSessionManager.swift in Sources */,
 				ED47DD4D27271781002AC5FB /* SlothSelectBoxInputFormView.swift in Sources */,
 				EDC4C3EF2736AFFC00B4E162 /* SlothDatePickerViewModel.swift in Sources */,
+				EDC4C407273806B500B4E162 /* SignedInTabBarController.swift in Sources */,
 				ED94035527191E1B006D32A6 /* EndPoint.swift in Sources */,
 				EDE5E08C272CC90D00B2AFAF /* LessonInformation.swift in Sources */,
 				ED94035327191536006D32A6 /* SignInRepository.swift in Sources */,
@@ -603,6 +618,7 @@
 				ED1ECBFA2728291D003FF62D /* LessonSite.swift in Sources */,
 				EDCFB889272EF92200DB7DFE /* RegisterLessonInformationViewPickerFactory.swift in Sources */,
 				EDE5E099272CD1EA00B2AFAF /* RegisterLessionViewNavigationType.swift in Sources */,
+				EDC4C4092738083A00B4E162 /* SignedInTabBarCoordinator.swift in Sources */,
 				EDAC0D95272E92DB00611039 /* AppCoordinator.swift in Sources */,
 				ED6BE9802724657B0011693B /* RegisterLessonInformationViewControllerFacotry.swift in Sources */,
 				ED2DC9032720415E003426D6 /* RegisterLessonViewController.swift in Sources */,

--- a/Nanagong/Nanagong/Common/AppCoordinator.swift
+++ b/Nanagong/Nanagong/Common/AppCoordinator.swift
@@ -14,6 +14,7 @@ final class AppCoordinator: Coordinator {
     private let viewControllerFactory: MainViewControllerFactory
     private lazy var rootViewController: UIViewController = viewControllerFactory.makeMainViewControlelr(self)
     private var onBoardingViewCoordinator: OnBoardingViewCoordinator?
+    private var signedInTabBarCoordinator: SignedInTabBarCoordinator?
     
     init(window: UIWindow?) {
         self.window = window
@@ -36,12 +37,15 @@ final class AppCoordinator: Coordinator {
         onBoardingViewCoordinator?.remove()
         onBoardingViewCoordinator = nil
         
-        let vc = UIViewController()
-        vc.view.backgroundColor = .blue
-        rootViewController.addFullScreen(childViewController: vc)
+        signedInTabBarCoordinator = makeSignedInTabBarCoordinator()
+        signedInTabBarCoordinator?.start()
     }
     
     private func makeOnBoardingViewCoordinator() -> OnBoardingViewCoordinator {
+        return .init(parentCoordinator: self, presenter: rootViewController, dependecy: dependencyContainer)
+    }
+    
+    private func makeSignedInTabBarCoordinator() -> SignedInTabBarCoordinator {
         return .init(parentCoordinator: self, presenter: rootViewController, dependecy: dependencyContainer)
     }
 }

--- a/Nanagong/Nanagong/Common/AppCoordinator.swift
+++ b/Nanagong/Nanagong/Common/AppCoordinator.swift
@@ -13,7 +13,7 @@ final class AppCoordinator: Coordinator {
     private var window: UIWindow?
     private let viewControllerFactory: MainViewControllerFactory
     private lazy var rootViewController: UIViewController = viewControllerFactory.makeMainViewControlelr(self)
-    private var onboardingViewCoordinator: OnBoardingViewCoordinator?
+    private var onBoardingViewCoordinator: OnBoardingViewCoordinator?
     
     init(window: UIWindow?) {
         self.window = window
@@ -28,11 +28,17 @@ final class AppCoordinator: Coordinator {
     }
     
     func presentWelcomeView() {
-        onboardingViewCoordinator = makeOnBoardingViewCoordinator()
-        onboardingViewCoordinator?.start()
+        onBoardingViewCoordinator = makeOnBoardingViewCoordinator()
+        onBoardingViewCoordinator?.start()
     }
     
     func presentSignedInView() {
+        onBoardingViewCoordinator?.remove()
+        onBoardingViewCoordinator = nil
+        
+        let vc = UIViewController()
+        vc.view.backgroundColor = .blue
+        rootViewController.addFullScreen(childViewController: vc)
     }
     
     private func makeOnBoardingViewCoordinator() -> OnBoardingViewCoordinator {

--- a/Nanagong/Nanagong/Common/AppCoordinator.swift
+++ b/Nanagong/Nanagong/Common/AppCoordinator.swift
@@ -28,6 +28,8 @@ final class AppCoordinator: Coordinator {
     }
     
     func presentWelcomeView() {
+        onboardingViewCoordinator = makeOnBoardingViewCoordinator()
+        onboardingViewCoordinator?.start()
     }
     
     func presentSignedInView() {

--- a/Nanagong/Nanagong/Common/AppCoordinator.swift
+++ b/Nanagong/Nanagong/Common/AppCoordinator.swift
@@ -11,20 +11,29 @@ final class AppCoordinator: Coordinator {
     
     let dependencyContainer: SlothAppDependencyContainer
     private var window: UIWindow?
-    private let rootViewController: UINavigationController
-    private let onboardingViewCoordinator: OnBoardingViewCoordinator
+    private let viewControllerFactory: MainViewControllerFactory
+    private lazy var rootViewController: UIViewController = viewControllerFactory.makeMainViewControlelr(self)
+    private var onboardingViewCoordinator: OnBoardingViewCoordinator?
     
     init(window: UIWindow?) {
         self.window = window
         self.dependencyContainer = .init(window: window, keyChainManager: KeyChainWrapperManager())
-        self.rootViewController = UINavigationController()
-        self.onboardingViewCoordinator = .init(presenter: rootViewController, dependecy: dependencyContainer)
+        self.viewControllerFactory = .init(dependency: dependencyContainer)
     }
     
     func start() {
         window?.rootViewController = rootViewController
         window?.overrideUserInterfaceStyle = .light
-        onboardingViewCoordinator.start()
         window?.makeKeyAndVisible()
+    }
+    
+    func presentWelcomeView() {
+    }
+    
+    func presentSignedInView() {
+    }
+    
+    private func makeOnBoardingViewCoordinator() -> OnBoardingViewCoordinator {
+        return .init(parentCoordinator: self, presenter: rootViewController, dependecy: dependencyContainer)
     }
 }

--- a/Nanagong/Nanagong/Common/MainViewControllerFactory.swift
+++ b/Nanagong/Nanagong/Common/MainViewControllerFactory.swift
@@ -1,0 +1,25 @@
+//
+//  MainViewControllerFactory.swift
+//  Nanagong
+//
+//  Created by Olaf on 2021/11/07.
+//
+
+import UIKit
+
+final class MainViewControllerFactory {
+    
+    private let dependency: SlothAppDependencyContainer
+    
+    init(dependency: SlothAppDependencyContainer) {
+        self.dependency = dependency
+    }
+    
+    func makeMainViewControlelr(_ coordinator: AppCoordinator) -> MainViewController {
+        return .init(coordinator: coordinator, viewModel: makeMainViewModel())
+    }
+    
+    private func makeMainViewModel() -> MainViewModel {
+        return .init(dependecy: dependency)
+    }
+}

--- a/Nanagong/Nanagong/Common/MainViewModel.swift
+++ b/Nanagong/Nanagong/Common/MainViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  MainViewModel.swift
+//  Nanagong
+//
+//  Created by Olaf on 2021/11/07.
+//
+
+import Combine
+import Foundation
+
+final class MainViewModel {
+    
+    enum State {
+        
+        case signedOut
+        
+        case signedIn
+    }
+    
+    @Published var state: State = .signedOut
+    
+    private let dependency: SlothAppDependencyContainer
+    
+    init(dependecy: SlothAppDependencyContainer) {
+        self.dependency = dependecy
+    }
+}

--- a/Nanagong/Nanagong/Common/MainViewModel.swift
+++ b/Nanagong/Nanagong/Common/MainViewModel.swift
@@ -24,4 +24,47 @@ final class MainViewModel {
     init(dependecy: SlothAppDependencyContainer) {
         self.dependency = dependecy
     }
+    
+    func checkHasToken() {
+        if validateAccessToken() {
+            state = .signedIn
+        } else {
+            state = .signedOut
+        }
+    }
+    
+    private func validateAccessToken() -> Bool {
+        if validateExistAccessToken() && validateAccessTokenExpireTime() {
+            return true
+        } else {
+            removeAllTokenInfo()
+            return false
+        }
+    }
+    
+    private func validateExistAccessToken() -> Bool {
+        return dependency.keyChainManager.isExistKey(key: .accessToken)
+    }
+    
+    private func validateAccessTokenExpireTime() -> Bool {
+        let dateFormatter = DateFormatter.init()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        
+        let accessTokenExpireTime = dependency.keyChainManager.getValue(forKey: .accessTokenExpireTime)
+        let accessTokenExpireDate = dateFormatter.date(from: accessTokenExpireTime) ?? Date.init()
+        let currentDate = Date.init()
+        
+        if currentDate >= accessTokenExpireDate {
+            return false
+        }
+        
+        return true
+    }
+    
+    private func removeAllTokenInfo() {
+        dependency.keyChainManager.remove(forKey: .accessToken)
+        dependency.keyChainManager.remove(forKey: .accessTokenExpireTime)
+        dependency.keyChainManager.remove(forKey: .refreshToken)
+        dependency.keyChainManager.remove(forKey: .refreshTokenExpireTime)
+    }
 }

--- a/Nanagong/Nanagong/Common/UIViewController+Child.swift
+++ b/Nanagong/Nanagong/Common/UIViewController+Child.swift
@@ -1,0 +1,46 @@
+//
+//  UIViewController+Child.swift
+//  Nanagong
+//
+//  Created by Olaf on 2021/11/07.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    // MARK: - Methods
+    public func addFullScreen(childViewController child: UIViewController) {
+        guard child.parent == nil else {
+            return
+        }
+        
+        addChild(child)
+        view.addSubview(child.view)
+        
+        child.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: child.view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: child.view.trailingAnchor),
+            view.topAnchor.constraint(equalTo: child.view.topAnchor),
+            view.bottomAnchor.constraint(equalTo: child.view.bottomAnchor)
+        ])
+        
+        child.didMove(toParent: self)
+    }
+    
+    public func remove(childViewController child: UIViewController?) {
+        guard let child = child else {
+            return
+        }
+        
+        guard child.parent != nil else {
+            return
+        }
+        
+        child.willMove(toParent: nil)
+        child.view.removeFromSuperview()
+        child.removeFromParent()
+    }
+}

--- a/Nanagong/Nanagong/MainViewController/MainViewController.swift
+++ b/Nanagong/Nanagong/MainViewController/MainViewController.swift
@@ -29,10 +29,12 @@ final class MainViewController: UIViewController {
         super.viewDidLoad()
         
         bind()
+        viewModel.checkHasToken()
     }
     
     private func bind() {
         viewModel.$state
+            .dropFirst()
             .sink { [weak self] state in
                 switch state {
                 case .signedOut:

--- a/Nanagong/Nanagong/MainViewController/MainViewController.swift
+++ b/Nanagong/Nanagong/MainViewController/MainViewController.swift
@@ -1,0 +1,46 @@
+//
+//  MainViewController.swift
+//  Nanagong
+//
+//  Created by Olaf on 2021/11/07.
+//
+
+import Combine
+import UIKit
+
+final class MainViewController: UIViewController {
+        
+    private unowned var coordinator: AppCoordinator
+    private let viewModel: MainViewModel
+    private var anyCancellables: Set<AnyCancellable> = .init()
+    
+    init(coordinator: AppCoordinator, viewModel: MainViewModel) {
+        self.coordinator = coordinator
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        bind()
+    }
+    
+    private func bind() {
+        viewModel.$state
+            .sink { [weak self] state in
+                switch state {
+                case .signedOut:
+                    self?.coordinator.presentWelcomeView()
+                    
+                case .signedIn:
+                    self?.coordinator.presentSignedInView()
+                }
+            }.store(in: &anyCancellables)
+    }
+}

--- a/Nanagong/Nanagong/OnboardingView/OnBoardingViewController.swift
+++ b/Nanagong/Nanagong/OnboardingView/OnBoardingViewController.swift
@@ -89,6 +89,7 @@ final class OnBoardingViewController: UIViewController {
     private func render() {
         viewModel.$viewState
             .dropFirst()
+            .removeDuplicates()
             .sink { [weak self] state in
                 self?.coordinator.present(with: state)
             }

--- a/Nanagong/Nanagong/OnboardingView/OnBoardingViewCoordinator.swift
+++ b/Nanagong/Nanagong/OnboardingView/OnBoardingViewCoordinator.swift
@@ -9,7 +9,8 @@ import UIKit
 
 final class OnBoardingViewCoordinator: Coordinator {
     
-    private let presenter: UINavigationController
+    private unowned var parentCoordinator: AppCoordinator
+    private unowned var presenter: UIViewController
     private let dependecy: SlothAppDependencyContainer
     private let onBoardingViewControllerFactory: OnBoardingViewControllerFactory
     private var onBoardingViewController: OnBoardingViewController?
@@ -17,7 +18,8 @@ final class OnBoardingViewCoordinator: Coordinator {
     private var signInViewCoordinator: SignInViewCoordinator?
     private var privacyPolicyViewCoordinator: PrivacyPolicyViewCoordinator?
     
-    init(presenter: UINavigationController, dependecy: SlothAppDependencyContainer) {
+    init(parentCoordinator: AppCoordinator, presenter: UIViewController, dependecy: SlothAppDependencyContainer) {
+        self.parentCoordinator = parentCoordinator
         self.presenter = presenter
         self.dependecy = dependecy
         self.onBoardingViewControllerFactory = .init(dependecy: dependecy)
@@ -27,7 +29,7 @@ final class OnBoardingViewCoordinator: Coordinator {
         let onBoardingViewController = onBoardingViewControllerFactory.makeOnBoardingViewController(with: self)
         self.onBoardingViewController = onBoardingViewController
         
-        presenter.viewControllers = [onBoardingViewController]
+        presenter.addFullScreen(childViewController: onBoardingViewController)
     }
     
     func present(with state: OnBoardingViewModel.OnBoardingViewState) {
@@ -51,6 +53,6 @@ final class OnBoardingViewCoordinator: Coordinator {
     }
     
     private func makePrivacyPolicyViewCoordinator() -> PrivacyPolicyViewCoordinator {
-        return .init(presenter: onBoardingViewController)
+        return .init(parentCoordinator: self, presenter: onBoardingViewController)
     }
 }

--- a/Nanagong/Nanagong/OnboardingView/OnBoardingViewCoordinator.swift
+++ b/Nanagong/Nanagong/OnboardingView/OnBoardingViewCoordinator.swift
@@ -42,8 +42,8 @@ final class OnBoardingViewCoordinator: Coordinator {
             self.privacyPolicyViewCoordinator = makePrivacyPolicyViewCoordinator()
             privacyPolicyViewCoordinator?.start()
             
-        default:
-            break
+        case .next:
+            parentCoordinator.presentSignedInView()
         }
     }
     

--- a/Nanagong/Nanagong/OnboardingView/OnBoardingViewCoordinator.swift
+++ b/Nanagong/Nanagong/OnboardingView/OnBoardingViewCoordinator.swift
@@ -47,6 +47,10 @@ final class OnBoardingViewCoordinator: Coordinator {
         }
     }
     
+    func remove() {
+        presenter.remove(childViewController: onBoardingViewController)
+    }
+    
     private func makeSignInViewCoordinator() -> SignInViewCoordinator {
         return .init(presenter: onBoardingViewController,
                      signInViewControllerFactory: onBoardingViewControllerFactory.makeSignInViewControllerFactory())

--- a/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewController.swift
+++ b/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewController.swift
@@ -149,7 +149,7 @@ final class PrivacyPolicyViewController: UIViewController {
     
     @objc
     private func agreePocily() {
-        
+        coordinator.signInDone()
     }
     
     @objc

--- a/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewController.swift
+++ b/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewController.swift
@@ -74,6 +74,17 @@ final class PrivacyPolicyViewController: UIViewController {
         return button
     }()
     
+    private unowned var coordinator: PrivacyPolicyViewCoordinator
+    
+    init(coordinator: PrivacyPolicyViewCoordinator) {
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewCoordinator.swift
+++ b/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewCoordinator.swift
@@ -10,15 +10,17 @@ import UIKit
 
 final class PrivacyPolicyViewCoordinator: NSObject, Coordinator {
     
-    private let presenter: UIViewController?
     private var privacyPolicyViewController: PrivacyPolicyViewController?
+    private unowned var presenter: UIViewController?
+    private unowned var parentCoordinator: OnBoardingViewCoordinator
     
-    init(presenter: UIViewController?) {
+    init(parentCoordinator: OnBoardingViewCoordinator, presenter: UIViewController?) {
+        self.parentCoordinator = parentCoordinator
         self.presenter = presenter
     }
     
     func start() {
-        let privacyPolicyViewController = PrivacyPolicyViewController()
+        let privacyPolicyViewController = PrivacyPolicyViewController(coordinator: self)
         
         privacyPolicyViewController.modalPresentationStyle = .custom
         privacyPolicyViewController.transitioningDelegate = self

--- a/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewCoordinator.swift
+++ b/Nanagong/Nanagong/OnboardingView/PrivacyPolicyView/PrivacyPolicyViewCoordinator.swift
@@ -29,6 +29,11 @@ final class PrivacyPolicyViewCoordinator: NSObject, Coordinator {
         
         presenter?.present(privacyPolicyViewController, animated: true, completion: nil)
     }
+    
+    func signInDone() {
+        privacyPolicyViewController?.dismiss(animated: true, completion: nil)
+        parentCoordinator.present(with: .next)
+    }
 }
 
 extension PrivacyPolicyViewCoordinator: DimPresentationControllerDelegate {

--- a/Nanagong/Nanagong/SignedInView/SignedInTabBarController.swift
+++ b/Nanagong/Nanagong/SignedInView/SignedInTabBarController.swift
@@ -1,0 +1,15 @@
+//
+//  SignedInTabBarController.swift
+//  Nanagong
+//
+//  Created by Olaf on 2021/11/07.
+//
+
+import UIKit
+
+final class SignedInTabBarController: UITabBarController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Nanagong/Nanagong/SignedInView/SignedInTabBarCoordinator.swift
+++ b/Nanagong/Nanagong/SignedInView/SignedInTabBarCoordinator.swift
@@ -1,0 +1,27 @@
+//
+//  SignedInTabBarCoordinator.swift
+//  Nanagong
+//
+//  Created by Olaf on 2021/11/07.
+//
+
+import UIKit
+
+final class SignedInTabBarCoordinator: Coordinator {
+
+    private unowned var parentCoordinator: AppCoordinator
+    private unowned var presenter: UIViewController
+    private unowned var dependecy: SlothAppDependencyContainer
+    private let viewController: SignedInTabBarController
+    
+    init(parentCoordinator: AppCoordinator, presenter: UIViewController, dependecy: SlothAppDependencyContainer) {
+        self.parentCoordinator = parentCoordinator
+        self.presenter = presenter
+        self.dependecy = dependecy
+        self.viewController = SignedInTabBarController()
+    }
+    
+    func start() {
+        presenter.addFullScreen(childViewController: viewController)
+    }
+}


### PR DESCRIPTION
앱이 시작하면 AppCoordinator에서 MainViewController를 rootViewController로 가집니다.
이 뷰컨은 앱이 살아있는동안 같이 살아있고, 특정 분기에 따라(로그인 여부 등) child view를 붙였다 떼면서 관리합니다.

로그인 여부는 승혁님이 만들어주신 OnBoardingViewModel의 로직을 그대로 가져왔습니다.
그런데 엑세스 토큰만 검사하고 있어서 든 생각인데, 추후에는 
1. 엑세스 토큰이 없다
2. 리프레시 토큰으로 요청한다.
3. 리프레시 토큰도 만료되었다.
4. 다시 로그인을 요구한다
라는 플로우가 되었으면 좋겠어요.

SignedInTabBarCoordinator에 로그인 이후에 들어갈 view의 Coordinator를 추가하면 될거같습니다.

추가적으로 앱 구조는 쿠버 앱을 많이 참고했어요.